### PR TITLE
Rewrite with procedural API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,18 @@
 [package]
 name = "derive_less"
-version = "0.1.7"
+version = "0.2.0"
 authors = ["Klas Segeljakt <klasseg@kth.se>"]
 readme = "README.md"
 repository = "https://github.com/segeljakt/derive_less"
 homepage = "https://github.com/segeljakt/derive_less"
 edition = "2018"
-description = """
-A library for generating `#[...]` and `pub` code for structs and enums.
-"""
+description = "A macro for templating item declarations."
 license = "MIT"
 
+[lib]
+proc-macro = true
+
 [dependencies]
+syn = { version = "0.15.39", features = ["full"] }
+proc-quote = "0.2.2"
+proc-macro2 = "0.4.30"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # derive_less
 
-A macro for deriving macros. Use it to generate `#[...]` and `pub` code in item declarations.
+A macro for templating item declarations.
 
 # Example
 
@@ -47,8 +47,8 @@ Instead of typing out `#[orange]`, `#[apple]`, and `pub`, repeatedly for each it
 use derive_less::derive_less;
 
 derive_less! {
-    #[derive(Debug)] pub struct ... { #[apple] pub ...  }
-    #[derive(Clone)] pub enum   ... { #[orange]    ...  }
+    #[derive(Debug)] pub struct __ { #[apple] pub __:__ }
+    #[derive(Clone)] pub enum   __ { #[orange]    __    }
 
     struct Foo(i32, i32);
     enum Bar {
@@ -70,8 +70,8 @@ You can also mix in derives that only apply to certain items/variants/fields, e.
 use derive_less::derive_less;
 
 derive_less! {
-    #[derive(Debug)] pub struct ... { #[apple] pub ...  }
-    #[derive(Clone)] pub enum   ... { #[orange]    ...  }
+    #[derive(Debug)] pub struct __ { #[apple] pub __:__  }
+    #[derive(Clone)] pub enum   __ { #[orange]    __     }
 
     struct Foo(i32, i32);
     enum Bar {
@@ -87,21 +87,3 @@ derive_less! {
     }
 }
 ```
-
-# Limitations
-
-Currently supports:
-* Structs (All kinds)
-* Enums (All kinds)
-
-# Future work
-
-Add support for:
-* Functions
-* Traits
-* Trait implementations
-* Unions
-* Type aliases
-* Use declarations
-
-Possibly rewrite `derive_less!` using Rust's procedural macro interface or through a build-script that generates declarative macro code. 

--- a/examples/enums.rs
+++ b/examples/enums.rs
@@ -1,11 +1,10 @@
-// #![feature(trace_macros)]
-
-// trace_macros!(true);
+#![allow(dead_code)]
+#![allow(unused_attributes)]
 
 use derive_less::derive_less;
 
 derive_less! {
-    #[derive(Clone)] #[derive(Debug)]  pub enum ... { #[derive(Clone)] ... }
+    #[derive(Clone)] #[derive(Debug)] pub enum __ { #[derive(Clone)] __ }
 
     enum Foo {
         A,

--- a/examples/fn.rs
+++ b/examples/fn.rs
@@ -1,15 +1,14 @@
-// https://github.com/segeljakt/derive_less/issues/1
-
 #![allow(dead_code)]
 #![allow(unused_attributes)]
 
 use derive_less::derive_less;
 
 derive_less! {
-    pub struct __ { __:__ }
 
-    struct S {
-        f: u8,
+    pub fn __() {}
+
+    fn foo() {
+
     }
 }
 

--- a/examples/issue_2.rs
+++ b/examples/issue_2.rs
@@ -1,9 +1,12 @@
 // https://github.com/segeljakt/derive_less/issues/2
 
+#![allow(dead_code)]
+#![allow(unused_attributes)]
+
 use derive_less::derive_less;
 
 derive_less! {
-    #[derive(Debug)] struct ... { pub ... }
+    #[derive(Debug)] struct __ { pub __:__ }
 
     struct S {
         f: u8,

--- a/examples/issue_3.rs
+++ b/examples/issue_3.rs
@@ -1,15 +1,18 @@
 // https://github.com/segeljakt/derive_less/issues/3
 
+#![allow(dead_code)]
+#![allow(unused_attributes)]
+
 use derive_less::derive_less;
 
-trait Trait {}
-
 derive_less! {
-    #[derive(Debug)] pub struct ... { pub ... }
+    #[derive(Debug)] pub struct __ { pub __:__ }
 
     struct S<T: Trait> {
         f: T,
     }
 }
+
+pub trait Trait {}
 
 fn main() {}

--- a/examples/issue_4.rs
+++ b/examples/issue_4.rs
@@ -1,13 +1,21 @@
 // https://github.com/segeljakt/derive_less/issues/4
 
+#![allow(dead_code)]
+#![allow(unused_attributes)]
+
 use derive_less::derive_less;
 
 derive_less! {
-    #[derive(Debug)] pub struct ... { pub(crate) ... }
+    #[derive(Debug)] pub struct __ { pub __:__ }
 
-    struct S {
-        f: u8,
+    struct S<T>
+    where
+        T: Trait,
+    {
+        f: T,
     }
 }
+
+pub trait Trait {}
 
 fn main() {}

--- a/examples/issue_6.rs
+++ b/examples/issue_6.rs
@@ -1,0 +1,16 @@
+// https://github.com/segeljakt/derive_less/issues/6
+
+#![allow(dead_code)]
+#![allow(unused_attributes)]
+
+use derive_less::derive_less;
+
+derive_less! {
+    #[derive(Debug)] pub struct __ { pub(crate) __:__ }
+
+    struct S {
+        f: u8,
+    }
+}
+
+fn main() {}

--- a/examples/mixed_public.rs
+++ b/examples/mixed_public.rs
@@ -1,7 +1,10 @@
+#![allow(dead_code)]
+#![allow(unused_attributes)]
+
 use derive_less::derive_less;
 
 derive_less! {
-    #[derive(Debug)] pub struct ... { #[derive(Clone)] pub ... }
+    #[derive(Debug)] pub struct __ { #[derive(Clone)] pub __:__ }
 
     struct Foo;
 

--- a/examples/permuted.rs
+++ b/examples/permuted.rs
@@ -1,0 +1,16 @@
+
+use derive_less::derive_less;
+
+derive_less! {
+
+    fn foo() { }
+
+    pub fn __() {}
+
+    const X: i32 = 0;
+
+}
+
+fn main() {
+
+}

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,8 +1,11 @@
+#![allow(dead_code)]
+#![allow(unused_attributes)]
+
 use derive_less::derive_less;
 
 derive_less! {
-    #[derive(Debug)] pub struct ... { #[derive(Debug)] pub ... }
-    #[derive(Clone)] pub enum   ... { #[derive(Debug)]     ... }
+    #[derive(Debug)] pub struct __ { #[derive(Debug)] pub __:__ }
+    #[derive(Clone)] pub enum   __ { #[derive(Debug)]     __    }
 
     struct Foo;
     struct Bar(f32, i32);
@@ -27,5 +30,5 @@ derive_less! {
         }
     }
 }
- 
+
 fn main() {}

--- a/examples/structs.rs
+++ b/examples/structs.rs
@@ -1,7 +1,10 @@
+#![allow(dead_code)]
+#![allow(unused_attributes)]
+
 use derive_less::derive_less;
 
 derive_less! {
-    #[derive(Clone)] #[derive(Debug)] pub struct ... { #[derive(Clone)] pub ... }
+    #[derive(Clone)] #[derive(Debug)] pub struct __ { #[derive(Clone)] pub __:__ }
 
     struct Foo {
         #[derive(PartialEq, PartialOrd)]

--- a/examples/tuple-structs.rs
+++ b/examples/tuple-structs.rs
@@ -1,7 +1,10 @@
+#![allow(dead_code)]
+#![allow(unused_attributes)]
+
 use derive_less::derive_less;
 
 derive_less! {
-    #[derive(Clone)] #[derive(Debug)] pub struct ... { #[derive(Clone)] pub ... }
+    #[derive(Clone)] #[derive(Debug)] pub struct __ { #[derive(Clone)] pub __:__ }
 
     struct Foo(i32);
     #[derive(PartialEq, PartialOrd)]

--- a/examples/unit-structs.rs
+++ b/examples/unit-structs.rs
@@ -1,8 +1,10 @@
+#![allow(dead_code)]
+#![allow(unused_attributes)]
 
 use derive_less::derive_less;
 
 derive_less! {
-    #[derive(Clone)] #[derive(Debug)]  pub struct ... { #[derive(Clone)] pub ... }
+    #[derive(Clone)] #[derive(Debug)] pub struct __ { #[derive(Clone)] pub __:__ }
 
     struct Foo;
     #[derive(PartialEq, PartialOrd)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,435 +1,116 @@
-#[macro_export]
-macro_rules! derive_less {
+extern crate proc_macro;
 
-    // READ TEMPLATES
+// use proc_macro_hack::proc_macro_hack;
+use proc_quote::quote;
 
-    // (Struct + Enum)
-    {
-        $(#[$smeta:meta])* $($svis:ident)? struct ... { $(#[$fmeta:meta])* $($fvis:ident)? ... }
-        $(#[$emeta:meta])* $($evis:ident)? enum   ... { $(#[$vmeta:meta])*                 ... }
-        $($rest:tt)*
-    } => {
-        $crate::derive_less! {
-            ($($smeta)*) ($($svis)?)
-            ($($fmeta)*) ($($fvis)?)
-            ($($emeta)*) ($($evis)?)
-            ($($vmeta)*)
-            $($rest)*
-        }
+const TEMPLATE_ID: &'static str = "__";
+
+#[proc_macro]
+pub fn derive_less(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let syn::File {
+        shebang,
+        attrs,
+        items,
+    } = syn::parse_macro_input!(input as syn::File);
+
+    let (templates, mut items) = partition(items);
+
+    let mut visitor = Visitor::from(templates);
+
+    for ref mut item in items.iter_mut() {
+        visitor.visit(item);
+    }
+
+    let new = syn::File {
+        shebang,
+        attrs,
+        items,
     };
 
-    // (Enum + Struct)
-    {
-        $(#[$emeta:meta])* $($evis:ident)? enum   ... { $(#[$vmeta:meta])*                 ... }
-        $(#[$smeta:meta])* $($svis:ident)? struct ... { $(#[$fmeta:meta])* $($fvis:ident)? ... }
-        $($rest:tt)*
-    } => {
-        $crate::derive_less! {
-            ($($smeta)*) ($($svis)?)
-            ($($fmeta)*) ($($fvis)?)
-            ($($emeta)*) ($($evis)?)
-            ($($vmeta)*)
-            $($rest)*
-        }
-    };
+    proc_macro::TokenStream::from(quote!(#new))
+}
 
-    // Struct
-    {
-        $(#[$smeta:meta])* $($svis:ident)? struct ... { $(#[$fmeta:meta])* $($fvis:ident)? ... }
-        $($rest:tt)*
-    } => {
-        $crate::derive_less! {
-            ($($smeta)*) ($($svis)?)
-            ($($fmeta)*) ($($fvis)?)
-            (          ) (         )
-            (          )
-            $($rest)*
-        }
-    };
+struct Visitor {
+    template_struct: Option<syn::ItemStruct>,
+    template_enum: Option<syn::ItemEnum>,
+    template_fn: Option<syn::ItemFn>,
+}
 
-    // Enum
-    {
-        $(#[$emeta:meta])* $($evis:ident)? enum   ... { $(#[$vmeta:meta])*                 ... }
-        $($rest:tt)*
-    } => {
-        $crate::derive_less! {
-            (          ) (         )
-            (          ) (         )
-            ($($emeta)*) ($($evis)?)
-            ($($vmeta)*)
-            $($rest)*
-        }
-    };
+fn partition(items: Vec<syn::Item>) -> (Vec<syn::Item>, Vec<syn::Item>) {
+    items.into_iter().partition(|item| match item {
+        syn::Item::Struct(item) => item.ident == TEMPLATE_ID,
+        syn::Item::Enum(item) => item.ident == TEMPLATE_ID,
+        syn::Item::Fn(item) => item.ident == TEMPLATE_ID,
+        _ => false,
+    })
+}
 
-    // TRANSFORM ITEMS
- 
-    // Struct (Begin)
-    {
-        ($($smeta:meta)*) ($($svis:ident)?)
-        ($($fmeta:meta)*) ($($fvis:ident)?)
-        ($($emeta:meta)*) ($($evis:ident)?)
-        ($($vmeta:meta)*)
-
-        $(#[$current_smeta:meta])*
-        struct
-
-        $($rest:tt)*
-    } => {
-        $crate::derive_less! {
-            ($($smeta)*) ($($svis)?)
-            ($($fmeta)*) ($($fvis)?)
-            ($($emeta)*) ($($evis)?)
-            ($($vmeta)*)
-
-            ($($fmeta)*)
-            $(#[$current_smeta])*
-            struct
-
-            $($rest)*
-        }
-    };
-
-    // Struct (Fields with meta)
-    {
-        ($($smeta:meta)*) ($($svis:ident)?)
-        ($($fmeta:meta)*) ($($fvis:ident)?)
-        ($($emeta:meta)*) ($($evis:ident)?)
-        ($($vmeta:meta)*)
-
-        ($first:meta $($apply:meta)*)
-        $(#[$current_smeta:meta])*
-        struct $sname:ident $(< $($generic:tt),+ $(,)? >)? {
-            $(
-                $(#[$current_fmeta:meta])*
-                $fname:ident : $fty:ty
-            ),+ $(,)?
-        }
-
-        $($rest:tt)*
-    } => {
-        $crate::derive_less! {
-            ($($smeta)*) ($($svis)?)
-            ($($fmeta)*) ($($fvis)?)
-            ($($emeta)*) ($($evis)?)
-            ($($vmeta)*)
-
-            ($($apply)*)
-            $(#[$current_smeta])*
-            struct $sname $(< $($generic),+ >)? {
-                $(
-                    $(#[$current_fmeta])*
-                    #[$first]
-                    $fname : $fty
-                ),+
+impl Visitor {
+    fn from(templates: Vec<syn::Item>) -> Self {
+        let mut visitor = Self {
+            template_struct: None,
+            template_enum: None,
+            template_fn: None,
+        };
+        for template in templates {
+            match template {
+                syn::Item::Struct(template) => visitor.template_struct = Some(template),
+                syn::Item::Enum(template) => visitor.template_enum = Some(template),
+                syn::Item::Fn(template) => visitor.template_fn = Some(template),
+                _ => {}
             }
-
-            $($rest)*
         }
-    };
+        visitor
+    }
 
-    // Struct (Fields with pub)
-    {
-        ($($smeta:meta)*) ($($svis:ident)?)
-        ($($fmeta:meta)*) (  $fvis:ident  )
-        ($($emeta:meta)*) ($($evis:ident)?)
-        ($($vmeta:meta)*)
-
-        ()
-        $(#[$current_smeta:meta])*
-        struct $sname:ident $(< $($generic:tt),+ $(,)? >)? {
-            $(
-                $(#[$current_fmeta:meta])*
-                $fname:ident : $fty:ty
-            ),+ $(,)?
-        }
-
-        $($rest:tt)*
-    } => {
-        $(#[$current_smeta])*
-        $(#[$smeta])*
-        $($svis)?
-        struct $sname $(< $($generic),+ >)? {
-            $(
-                $(#[$current_fmeta])*
-                $fvis $fname : $fty
-            ),+
-        }
-
-        $crate::derive_less! {
-            ($($smeta)*) ($($svis)?)
-            ($($fmeta)*) (  $fvis  )
-            ($($emeta)*) ($($evis)?)
-            ($($vmeta)*)
-            $($rest)*
-        }
-    };
-
-    // Struct (Fields without pub)
-    {
-        ($($smeta:meta)*) ($($svis:ident)?)
-        ($($fmeta:meta)*) (               )
-        ($($emeta:meta)*) ($($evis:ident)?)
-        ($($vmeta:meta)*)
-
-        ()
-        $(#[$current_smeta:meta])*
-        struct $sname:ident $(< $($generic:tt),+ $(,)? >)? {
-            $(
-                $(#[$current_fmeta:meta])*
-                $fname:ident : $fty:ty
-            ),+ $(,)?
-        }
-
-        $($rest:tt)*
-    } => {
-        $(#[$current_smeta])*
-        $(#[$smeta])*
-        $($svis)?
-        struct $sname $(< $($generic),+ >)? {
-            $(
-                $(#[$current_fmeta])*
-                $fname : $fty
-            ),+
-        }
-
-        $crate::derive_less! {
-            ($($smeta)*) ($($svis)?)
-            ($($fmeta)*) (         )
-            ($($emeta)*) ($($evis)?)
-            ($($vmeta)*)
-            $($rest)*
-        }
-    };
-
-    // Unit struct / Tuple struct (Fields with meta)
-    {
-        ($($smeta:meta)*) ($($svis:ident)?)
-        ($($fmeta:meta)*) ($($fvis:ident)?)
-        ($($emeta:meta)*) ($($evis:ident)?)
-        ($($vmeta:meta)*)
-
-        ($first:meta $($apply:meta)*)
-        $(#[$current_smeta:meta])*
-        struct $sname:ident $(< $($generic:tt),+ $(,)? >)? $((
-            $(
-                $(#[$current_fmeta:meta])*
-                $fty:ty
-            ),+ $(,)?
-        ))?;
-
-        $($rest:tt)*
-    } => {
-        $crate::derive_less! {
-            ($($smeta)*) ($($svis)?)
-            ($($fmeta)*) ($($fvis)?)
-            ($($emeta)*) ($($evis)?)
-            ($($vmeta)*)
-
-            ($($apply)*)
-            $(#[$current_smeta])*
-            struct $sname $(< $($generic),+ >)? $((
-                $(
-                    $(#[$current_fmeta])*
-                    #[$first]
-                    $fty
-                ),+
-            ))?;
-
-            $($rest)*
-        }
-    };
-
-    // Unit struct / Tuple struct (Fields with pub)
-    {
-        ($($smeta:meta)*) ($($svis:ident)?)
-        ($($fmeta:meta)*) (  $fvis:ident  )
-        ($($emeta:meta)*) ($($evis:ident)?)
-        ($($vmeta:meta)*)
-
-        ()
-        $(#[$current_smeta:meta])*
-        struct $sname:ident $(< $($generic:tt),+ $(,)? >)? $((
-            $(
-                $(#[$current_fmeta:meta])*
-                $fty:ty
-            ),+ $(,)?
-        ))?;
-
-        $($rest:tt)*
-    } => {
-        $(#[$current_smeta])*
-        $(#[$smeta])*
-        $($svis)?
-        struct $sname $(< $($generic),+ >)? $((
-            $(
-                $(#[$current_fmeta])*
-                $fvis $fty
-            ),+
-        ))?;
-
-        $crate::derive_less! {
-            ($($smeta)*) ($($svis)?)
-            ($($fmeta)*) (  $fvis  )
-            ($($emeta)*) ($($evis)?)
-            ($($vmeta)*)
-            $($rest)*
-        }
-    };
-
-    // Unit struct / Tuple struct (Fields without pub)
-    {
-        ($($smeta:meta)*) ($($svis:ident)?)
-        ($($fmeta:meta)*) (               )
-        ($($emeta:meta)*) ($($evis:ident)?)
-        ($($vmeta:meta)*)
-
-        ()
-        $(#[$current_smeta:meta])*
-        struct $sname:ident $(< $($generic:tt),+ $(,)? >)? $((
-            $(
-                $(#[$current_fmeta:meta])*
-                $fty:ty
-            ),+ $(,)?
-        ))?;
-
-        $($rest:tt)*
-    } => {
-        $(#[$current_smeta])*
-        $(#[$smeta])*
-        $($svis)?
-        struct $sname $(< $($generic),+ >)? $((
-            $(
-                $(#[$current_fmeta])*
-                $fty
-            ),+
-        ))?;
-
-        $crate::derive_less! {
-            ($($smeta)*) ($($svis)?)
-            ($($fmeta)*) (         )
-            ($($emeta)*) ($($evis)?)
-            ($($vmeta)*)
-            $($rest)*
-        }
-    };
-
-    // Enum (Begin)
-    {
-        ($($smeta:meta)*) ($($svis:ident)?)
-        ($($fmeta:meta)*) ($($fvis:ident)?)
-        ($($emeta:meta)*) ($($evis:ident)?)
-        ($($vmeta:meta)*)
-
-        $(#[$current_emeta:meta])*
-        enum
-
-        $($rest:tt)*
-    } => {
-        $crate::derive_less! {
-            ($($smeta)*) ($($svis)?)
-            ($($fmeta)*) ($($fvis)?)
-            ($($emeta)*) ($($evis)?)
-            ($($vmeta)*)
-
-            ($($vmeta)*)
-            $(#[$current_emeta])*
-            enum
-
-            $($rest)*
-        }
-    };
-
-    // Enum (Variants with meta)
-    {
-        ($($smeta:meta)*) ($($svis:ident)?)
-        ($($fmeta:meta)*) ($($fvis:ident)?)
-        ($($emeta:meta)*) ($($evis:ident)?)
-        ($($vmeta:meta)*)
-
-        ($first:meta $($apply:meta)*)
-        $(#[$current_emeta:meta])*
-        enum $ename:ident $(< $($generic:tt),+ $(,)? >)? {
-            $(
-                $(#[$current_vmeta:meta])*
-                $vname:ident
-                $(( $($vty:ty),+ $(,)? ))?
-                $({ $($fname:ident : $fty:ty),+ $(,)? })?
-            ),+ $(,)?
-        }
-
-        $($rest:tt)*
-    } => {
-        $crate::derive_less! {
-            ($($smeta)*) ($($svis)?)
-            ($($fmeta)*) ($($fvis)?)
-            ($($emeta)*) ($($evis)?)
-            ($($vmeta)*)
-
-            ($($apply)*)
-            $(#[$current_emeta])*
-            enum $ename $(< $($generic),+ >)? {
-                $(
-                    $(#[$current_vmeta])*
-                    #[$first]
-                    $vname
-                    $(( $($vty),+ ))?
-                    $({ $($fname : $fty),+ })?
-                ),+
+    fn visit(&mut self, item: &mut syn::Item) {
+        match item {
+            syn::Item::Struct(item) => {
+                if let Some(ref mut template) = self.template_struct {
+                    item.attrs.extend(template.attrs.clone());
+                    if let syn::Visibility::Inherited = item.vis {
+                        item.vis = template.vis.clone();
+                    }
+                    if let Some(ref mut template) = template.fields.iter().next() {
+                        for field in item.fields.iter_mut() {
+                            field.attrs.extend(template.attrs.clone());
+                            if let syn::Visibility::Inherited = field.vis {
+                                field.vis = template.vis.clone();
+                            }
+                        }
+                    }
+                }
             }
-
-            $($rest)*
+            syn::Item::Enum(item) => {
+                if let Some(ref mut template) = self.template_enum {
+                    item.attrs.extend(template.attrs.clone());
+                    if let syn::Visibility::Inherited = item.vis {
+                        item.vis = template.vis.clone();
+                    }
+                    if let Some(ref mut template) = template.variants.iter().next() {
+                        for variant in item.variants.iter_mut() {
+                            variant.attrs.extend(template.attrs.clone());
+                        }
+                        if let Some(ref mut template) = template.fields.iter().next() {
+                            for variant in item.variants.iter_mut() {
+                                for field in variant.fields.iter_mut() {
+                                    field.attrs.extend(template.attrs.clone());
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            syn::Item::Fn(item) => {
+                if let Some(ref mut template) = self.template_fn {
+                    item.attrs.extend(template.attrs.clone());
+                    if let syn::Visibility::Inherited = item.vis {
+                        item.vis = template.vis.clone();
+                    }
+                }
+            }
+            _ => {}
         }
-    };
-
-    // Enum (Done)
-    {
-        ($($smeta:meta)*) ($($svis:ident)?)
-        ($($fmeta:meta)*) ($($fvis:ident)?)
-        ($($emeta:meta)*) ($($evis:ident)?)
-        ($($vmeta:meta)*)
-
-        ()
-        $(#[$current_emeta:meta])*
-        enum $ename:ident $(< $($generic:tt),+ $(,)? >)? {
-            $(
-                $(#[$current_vmeta:meta])*
-                $vname:ident
-                $(( $($vty:ty),+ $(,)? ))?
-                $({ $($fname:ident : $fty:ty),+ $(,)? })?
-            ),+ $(,)?
-        }
-
-        $($rest:tt)*
-    } => {
-        $(#[$emeta])*
-        $(#[$current_emeta])*
-        $($evis)?
-        enum $ename $(< $($generic),+ >)? {
-            $(
-                $(#[$current_vmeta])*
-                $vname
-                $(( $($vty),+ ))?
-                $({ $($fname : $fty),+ })?
-            ),+
-        }
-
-        $crate::derive_less! {
-            ($($smeta)*) ($($svis)?)
-            ($($fmeta)*) ($($fvis)?)
-            ($($emeta)*) ($($evis)?)
-            ($($vmeta)*)
-            $($rest)*
-        }
-    };
-
-    // Exhausted
-    {
-        ($($smeta:meta)*) ($($svis:ident)?)
-        ($($fmeta:meta)*) ($($fvis:ident)?)
-        ($($emeta:meta)*) ($($evis:ident)?)
-        ($($vmeta:meta)*)
-//         $($rest:tt)*
-    } => {
-//         $($rest)*
     }
 }
+


### PR DESCRIPTION
This PR rewrites the implementation to use Rust's procedural, instead of declarative, macro API. This fixes all of the open issues, and improves maintainability. To the user, the only visible change is where you would previously write `...`, you now need to write `__`, as the template code needs to be parse-able by `syn`. For example:

```rust
use derive_less::derive_less;

derive_less! {
    pub struct ... { pub ... }

    struct S {
        f: u8,
    }
}
```

is now

```rust
use derive_less::derive_less;

derive_less! {
    pub struct __ { pub __:__ }

    struct S {
        f: u8,
    }
}
```

It is also now possible to create custom templates for `fn` declarations.

```rust
use derive_less::derive_less;

derive_less! {
    pub fn __() {}

    fn foo() { }
}
```

Finally, the order in which you put the templates and the actual items does not matter, and you can include other kinds of non-derivable items inside which `derive_less` won't touch.

```rust
use derive_less::derive_less;

derive_less! {
    fn foo() { }

    pub fn __() {}

    const X: i32 = 0;
}
```